### PR TITLE
Remove me from .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,5 +3,4 @@
 
 Nik Vaessen <nikvaes@gmail.com>
 Nik Vaessen <nikvaes@gmail.com> <nikvaessen@users.noreply.github.com>
-Boris Grovez <boris@jitsi.org>
 Bart van Andel <bavanandel@gmail.com>


### PR DESCRIPTION
I wanted to fix the typo in my name, but I'm only listed once in `git shortlog -nes` and I don't actually contribute to the project anyway.
