### PR TITLE
Expose Ops count in compute_measures

### DIFF
--- a/jiwer/measures.py
+++ b/jiwer/measures.py
@@ -208,6 +208,10 @@ def compute_measures(
         "mer": mer,
         "wil": wil,
         "wip": wip,
+        "hits": H,
+        "substitutions": S,
+        "deletions": D,
+        "insertions": I,
     }
 
 

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -110,6 +110,8 @@ class TestWERInputMethods(unittest.TestCase):
     def _apply_test_on(self, cases):
         for gt, h, correct_measures in cases:
             measures = jiwer.compute_measures(truth=gt, hypothesis=h)
+            # Remove entries we are not testing against
+            [measures.pop(k) for k in ["hits", "substitutions", "deletions", "insertions"]]
             self.assertDictAlmostEqual(measures, correct_measures, delta=1e-16)
 
     def assertDictAlmostEqual(self, a, b, places=None, msg=None, delta=None):


### PR DESCRIPTION
As mentioned in #13, this exposes them but doesn't impact the rest of the lib. 

If this is merged, could we release a new version after please? I need those counts for a downstream project

Thanks!