### PR TITLE
Tiny correction to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ sentences = ["is the world doomed or loved?", "edibles are allegedly cultivated"
 
 # note: the regex string "\b(\w+)ed\b", matches every word ending in 'ed', 
 # and "\1" stands for the first group ('\w+). It therefore removes 'ed' in every match.
-print(jiwer.SubstituteRegexes({r"doom": r"sacr", r"\b(\w+)ed\b": r"\1"}))
+print(jiwer.SubstituteRegexes({r"doom": r"sacr", r"\b(\w+)ed\b": r"\1"})(sentences))
 
 # prints: ["is the world sacr or lov?", "edibles are allegedly cultivat"]
 ```


### PR DESCRIPTION
The example code for SubstituteRegexes was missing the "(sentences)" part, unlike all the other examples; this simply adds it so it works as intended.