### PR TITLE
Update python-levenshtein with levenshtein

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple python package to approximate the Word Error Rate (WER), Match Error Rate (MER), Word Information Lost (WIL) and Word Information Preserved (WIP) of a transcript.
 It computes the minimum-edit distance between the ground-truth sentence and the hypothesis sentence of a speech-to-text API.
-The minimum-edit distance is calculated using the python C module [python-Levenshtein](https://github.com/ztane/python-Levenshtein).
+The minimum-edit distance is calculated using the Python C module [Levenshtein](https://github.com/maxbachmann/Levenshtein).
 
 _For a comparison between WER, MER and WIL, see: \
 Morris, Andrew & Maier, Viktoria & Green, Phil. (2004). [From WER and RIL to MER and WIL: improved evaluation measures for connected speech recognition.](https://www.researchgate.net/publication/221478089_From_WER_and_RIL_to_MER_and_WIL_improved_evaluation_measures_for_connected_speech_recognition)_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/jitsi/jiwer"
 include = ["LICENCE"]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7"
 levenshtein = "0.20.2"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["LICENCE"]
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-python-Levenshtein = "0.12.2"
+levenshtein = "0.20.2"
 
 [tool.poetry.dev-dependencies]
 black = "21.9b0"


### PR DESCRIPTION
python-levenshtein is not maintained and has been superseded by [`levenshtein`](https://github.com/maxbachmann/Levenshtein). It includes the same functionality and also a C engine. Usage is the same. Updating to `levenshtein` should improve usability as it comes with prebuilt wheels and will continue to have support for at least the near future, which is good news for the fast iterations in Python development.

closes #60 