### PR TITLE
compute the list of punctuation characters only once.

### DIFF
--- a/jiwer/transforms.py
+++ b/jiwer/transforms.py
@@ -22,6 +22,7 @@ of input strings to the desired format in order to calculate the WER.
 """
 
 import sys
+import functools
 import re
 import string
 import unicodedata
@@ -213,14 +214,20 @@ class RemoveWhiteSpace(BaseRemoveTransform):
         super().__init__(characters, replace_token=replace_token)
 
 
+@functools.lru_cache(1)
+def _get_punctuation_characters():
+    """Compute the punctuation characters only once and memoize."""
+    codepoints = range(sys.maxunicode + 1)
+    punctuation = set(
+        chr(i) for i in codepoints if unicodedata.category(chr(i)).startswith("P")
+    )
+    return punctuation
+
+
 class RemovePunctuation(BaseRemoveTransform):
     def __init__(self):
-        codepoints = range(sys.maxunicode + 1)
-        punctuation = set(
-            chr(i) for i in codepoints if unicodedata.category(chr(i)).startswith("P")
-        )
-
-        super().__init__(list(punctuation))
+        punctuation_characters = _get_punctuation_characters()
+        super().__init__(punctuation_characters)
 
 
 class RemoveMultipleSpaces(AbstractTransform):


### PR DESCRIPTION
The values from `unicodedata` should never change, so this will be a
constant value. On my machine this iterates over 1,114,112 elements to
compute the list. We don't need to recompute this every time and can
save the results of the punctuation characters so only the first time
a `RemovePunctuation` transform will take time and future calls will
reuse the character list.

Closes #66 