### PR TITLE
Added Aligned Words List Output 

### DIFF
--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -4,12 +4,7 @@ import jiwer
 
 class TestAlignmentVisualizationWords(unittest.TestCase):
     def test_insertion(self):
-        correct_alignment = (
-            "sentence 1\n"
-            "REF: this is a ****\n"
-            "HYP: this is a test\n"
-            "                  I\n"
-        )
+        correct_alignment = "sentence 1\n" "REF: this is a ****\n" "HYP: this is a test\n" "                  I\n"
         alignment = jiwer.visualize_alignment(
             jiwer.process_words("this is a", "this is a test"), show_measures=False
         )
@@ -18,12 +13,7 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
         pass
 
     def test_deletion(self):
-        correct_alignment = (
-            "sentence 1\n"
-            "REF: this is a test\n"
-            "HYP: this is a ****\n"
-            "                  D\n"
-        )
+        correct_alignment = "sentence 1\n" "REF: this is a test\n" "HYP: this is a ****\n" "                  D\n"
         alignment = jiwer.visualize_alignment(
             jiwer.process_words("this is a test", "this is a"), show_measures=False
         )
@@ -31,10 +21,7 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
 
     def test_substitution(self):
         correct_alignment = (
-            "sentence 1\n"
-            "REF: this  is a test\n"
-            "HYP: this was a test\n"
-            "            S       \n"
+            "sentence 1\n" "REF: this  is a test\n" "HYP: this was a test\n" "            S       \n"
         )
         alignment = jiwer.visualize_alignment(
             jiwer.process_words("this is a test", "this was a test"),
@@ -71,18 +58,14 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
             "wer=88.89%\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_words(
-                "this test will  have a high word error rate", "no it will not"
-            ),
+            jiwer.process_words("this test will  have a high word error rate", "no it will not"),
             show_measures=True,
         )
         self.assertEqual(alignment, correct_alignment)
 
     def test_empty_hypothesis(self):
         correct_alignment = "sentence 1\n" "REF: empty\n" "HYP: *****\n" "         D\n"
-        alignment = jiwer.visualize_alignment(
-            jiwer.process_words("empty", ""), show_measures=False
-        )
+        alignment = jiwer.visualize_alignment(jiwer.process_words("empty", ""), show_measures=False)
         self.assertEqual(alignment, correct_alignment)
 
     def test_multiple_sentences(self):
@@ -116,22 +99,34 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
             "       S\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_words(
-                ["perfect", "one", "two", "three"], ["perfect", "1", "2", "three"]
-            ),
+            jiwer.process_words(["perfect", "one", "two", "three"], ["perfect", "1", "2", "three"]),
             show_measures=False,
         )
         self.assertEqual(alignment, correct_alignment)
 
+    def test_get_alignment_words(self):
+        reference = ["this is a test of alignment words", "this is a test of the alignment words"]
+        hypothesis = ["this is a test of alignment words", "this is also a test of alignment wordz!"]
+        output = jiwer.process_words(reference, hypothesis)
+
+        reference_words, hypothesis_words, operation_chars = jiwer.get_alignment_words(
+            output.references[0], output.hypotheses[0], output.alignments[0]
+        )
+        self.assertEqual(reference_words, ["this", "is", "a", "test", "of", "alignment", "words"])
+        self.assertEqual(hypothesis_words, ["this", "is", "a", "test", "of", "alignment", "words"])
+        self.assertEqual(operation_chars, [" "] * len(reference_words))
+
+        reference_words, hypothesis_words, operation_chars = jiwer.get_alignment_words(
+            output.references[1], output.hypotheses[1], output.alignments[1]
+        )
+        self.assertEqual(reference_words, ["this", "is", "****", "a", "test", "of", "the", "alignment", "words"])
+        self.assertEqual(hypothesis_words, ["this", "is", "also", "a", "test", "of", "***", "alignment", "wordz!"])
+        self.assertEqual(operation_chars, [" ", " ", "I", " ", " ", " ", "D", " ", "S"])
+
 
 class TestAlignmentVisualizationCharacters(unittest.TestCase):
     def test_insertion(self):
-        correct_alignment = (
-            "sentence 1\n"
-            "REF: this is a*****\n"
-            "HYP: this is a test\n"
-            "              IIIII\n"
-        )
+        correct_alignment = "sentence 1\n" "REF: this is a*****\n" "HYP: this is a test\n" "              IIIII\n"
         alignment = jiwer.visualize_alignment(
             jiwer.process_characters("this is a", "this is a test"), show_measures=False
         )
@@ -140,24 +135,14 @@ class TestAlignmentVisualizationCharacters(unittest.TestCase):
         pass
 
     def test_deletion(self):
-        correct_alignment = (
-            "sentence 1\n"
-            "REF: this is a test\n"
-            "HYP: this is a*****\n"
-            "              DDDDD\n"
-        )
+        correct_alignment = "sentence 1\n" "REF: this is a test\n" "HYP: this is a*****\n" "              DDDDD\n"
         alignment = jiwer.visualize_alignment(
             jiwer.process_characters("this is a test", "this is a"), show_measures=False
         )
         self.assertEqual(alignment, correct_alignment)
 
     def test_substitution(self):
-        correct_alignment = (
-            "sentence 1\n"
-            "REF: this is a test\n"
-            "HYP: this iz a test\n"
-            "           S       \n"
-        )
+        correct_alignment = "sentence 1\n" "REF: this is a test\n" "HYP: this iz a test\n" "           S       \n"
         alignment = jiwer.visualize_alignment(
             jiwer.process_characters("this is a test", "this iz a test"),
             show_measures=False,
@@ -172,9 +157,7 @@ class TestAlignmentVisualizationCharacters(unittest.TestCase):
             "          IS    S  IS SSD SDDD\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_characters(
-                "this is a test of skill", "this was a messy test"
-            ),
+            jiwer.process_characters("this is a test of skill", "this was a messy test"),
             show_measures=False,
         )
         self.assertEqual(alignment, correct_alignment)
@@ -192,18 +175,14 @@ class TestAlignmentVisualizationCharacters(unittest.TestCase):
             "cer=76.74%\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_characters(
-                "this test will  have a high word error rate", "no it will not"
-            ),
+            jiwer.process_characters("this test will  have a high word error rate", "no it will not"),
             show_measures=True,
         )
         self.assertEqual(alignment, correct_alignment)
 
     def test_empty_hypothesis(self):
         correct_alignment = "sentence 1\n" "REF: empty\n" "HYP: *****\n" "     DDDDD\n"
-        alignment = jiwer.visualize_alignment(
-            jiwer.process_characters("empty", ""), show_measures=False
-        )
+        alignment = jiwer.visualize_alignment(jiwer.process_characters("empty", ""), show_measures=False)
         self.assertEqual(alignment, correct_alignment)
 
     def test_multiple_sentences(self):

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -4,7 +4,12 @@ import jiwer
 
 class TestAlignmentVisualizationWords(unittest.TestCase):
     def test_insertion(self):
-        correct_alignment = "sentence 1\n" "REF: this is a ****\n" "HYP: this is a test\n" "                  I\n"
+        correct_alignment = (
+            "sentence 1\n"
+            "REF: this is a ****\n"
+            "HYP: this is a test\n"
+            "                  I\n"
+        )
         alignment = jiwer.visualize_alignment(
             jiwer.process_words("this is a", "this is a test"), show_measures=False
         )
@@ -13,7 +18,12 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
         pass
 
     def test_deletion(self):
-        correct_alignment = "sentence 1\n" "REF: this is a test\n" "HYP: this is a ****\n" "                  D\n"
+        correct_alignment = (
+            "sentence 1\n"
+            "REF: this is a test\n"
+            "HYP: this is a ****\n"
+            "                  D\n"
+        )
         alignment = jiwer.visualize_alignment(
             jiwer.process_words("this is a test", "this is a"), show_measures=False
         )
@@ -21,7 +31,10 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
 
     def test_substitution(self):
         correct_alignment = (
-            "sentence 1\n" "REF: this  is a test\n" "HYP: this was a test\n" "            S       \n"
+            "sentence 1\n"
+            "REF: this  is a test\n"
+            "HYP: this was a test\n"
+            "            S       \n"
         )
         alignment = jiwer.visualize_alignment(
             jiwer.process_words("this is a test", "this was a test"),
@@ -58,14 +71,18 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
             "wer=88.89%\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_words("this test will  have a high word error rate", "no it will not"),
+            jiwer.process_words(
+                "this test will  have a high word error rate", "no it will not"
+            ),
             show_measures=True,
         )
         self.assertEqual(alignment, correct_alignment)
 
     def test_empty_hypothesis(self):
         correct_alignment = "sentence 1\n" "REF: empty\n" "HYP: *****\n" "         D\n"
-        alignment = jiwer.visualize_alignment(jiwer.process_words("empty", ""), show_measures=False)
+        alignment = jiwer.visualize_alignment(
+            jiwer.process_words("empty", ""), show_measures=False
+        )
         self.assertEqual(alignment, correct_alignment)
 
     def test_multiple_sentences(self):
@@ -99,7 +116,9 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
             "       S\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_words(["perfect", "one", "two", "three"], ["perfect", "1", "2", "three"]),
+            jiwer.process_words(
+                ["perfect", "one", "two", "three"], ["perfect", "1", "2", "three"]
+            ),
             show_measures=False,
         )
         self.assertEqual(alignment, correct_alignment)
@@ -126,7 +145,12 @@ class TestAlignmentVisualizationWords(unittest.TestCase):
 
 class TestAlignmentVisualizationCharacters(unittest.TestCase):
     def test_insertion(self):
-        correct_alignment = "sentence 1\n" "REF: this is a*****\n" "HYP: this is a test\n" "              IIIII\n"
+        correct_alignment = (
+            "sentence 1\n"
+            "REF: this is a*****\n"
+            "HYP: this is a test\n"
+            "              IIIII\n"
+        )
         alignment = jiwer.visualize_alignment(
             jiwer.process_characters("this is a", "this is a test"), show_measures=False
         )
@@ -135,14 +159,24 @@ class TestAlignmentVisualizationCharacters(unittest.TestCase):
         pass
 
     def test_deletion(self):
-        correct_alignment = "sentence 1\n" "REF: this is a test\n" "HYP: this is a*****\n" "              DDDDD\n"
+        correct_alignment = (
+            "sentence 1\n"
+            "REF: this is a test\n"
+            "HYP: this is a*****\n"
+            "              DDDDD\n"
+        )
         alignment = jiwer.visualize_alignment(
             jiwer.process_characters("this is a test", "this is a"), show_measures=False
         )
         self.assertEqual(alignment, correct_alignment)
 
     def test_substitution(self):
-        correct_alignment = "sentence 1\n" "REF: this is a test\n" "HYP: this iz a test\n" "           S       \n"
+        correct_alignment = (
+            "sentence 1\n"
+            "REF: this is a test\n"
+            "HYP: this iz a test\n"
+            "           S       \n"
+        )
         alignment = jiwer.visualize_alignment(
             jiwer.process_characters("this is a test", "this iz a test"),
             show_measures=False,
@@ -157,7 +191,9 @@ class TestAlignmentVisualizationCharacters(unittest.TestCase):
             "          IS    S  IS SSD SDDD\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_characters("this is a test of skill", "this was a messy test"),
+            jiwer.process_characters(
+                "this is a test of skill", "this was a messy test"
+            ),
             show_measures=False,
         )
         self.assertEqual(alignment, correct_alignment)
@@ -175,14 +211,18 @@ class TestAlignmentVisualizationCharacters(unittest.TestCase):
             "cer=76.74%\n"
         )
         alignment = jiwer.visualize_alignment(
-            jiwer.process_characters("this test will  have a high word error rate", "no it will not"),
+            jiwer.process_characters(
+                "this test will  have a high word error rate", "no it will not"
+            ),
             show_measures=True,
         )
         self.assertEqual(alignment, correct_alignment)
 
     def test_empty_hypothesis(self):
         correct_alignment = "sentence 1\n" "REF: empty\n" "HYP: *****\n" "     DDDDD\n"
-        alignment = jiwer.visualize_alignment(jiwer.process_characters("empty", ""), show_measures=False)
+        alignment = jiwer.visualize_alignment(
+            jiwer.process_characters("empty", ""), show_measures=False
+        )
         self.assertEqual(alignment, correct_alignment)
 
     def test_multiple_sentences(self):


### PR DESCRIPTION
Sometimes one needs to get lists of aligned words from the given sentences. 

This PR extracts that logic from `_construct_comparison_string` into `get_alignment_words` and exposes it publicly to be used when one needs to process aligned words.